### PR TITLE
Update library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=PCA9557 Driver (8-Channel GPIO I2C Expander)
 paragraph=This library contains a complete driver for the PCA9557 exposing all its functionality so that its 8 channels (or IO pins) can be controlled as a single unit or individually in terms of their Mode (INPUT /OUTPUT) and Polarity (NON-INVERTED / INVERTED). The pins' states (LOW / HIGH) can be read (in INPUT mode) or written (in OUTPUT mode).
 url=https://github.com/wagnerosss/PCA9557
 category=Signal Input/Output
-architectures=avr/arm
+architectures=*


### PR DESCRIPTION
The previous `architectures` value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library PCA9557 claims to run on (avr/arm) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```
The previous `architectures` value caused the library's examples to be placed under the **File > Examples > INCOMPATIBLE** menu.

Although it's possible to specify specific architecture values when needed, it appears there is no architecture-specific code in the library and so I have chosen to use a wildcard value.